### PR TITLE
Fix Supabase env var name in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ npm run build
 3. **Set Environment Variables**:
    ```
    VITE_SUPABASE_URL=your-supabase-url
-   VITE_SUPABASE_ANON_KEY=your-anon-key
+   VITE_SUPABASE_KEY=your-supabase-key
    VITE_SUPABASE_EDGE_FUNCTION_URL=The URL for Supabase edge functions used in search operations.
    VITE_CACHE_SYNC_INTERVAL=The interval (in milliseconds) for cache synchronization.
    VITE_CACHE_WEBHOOK_URL=The webhook URL for cache data synchronization.


### PR DESCRIPTION
## Summary
- use `VITE_SUPABASE_KEY` consistently in README

## Testing
- `npm run lint` *(fails: 9 errors, 20 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68552f243948832c90ce31da4e4cc5dd