### PR TITLE
Update SearchHistory props

### DIFF
--- a/src/components/SearchHistory.tsx
+++ b/src/components/SearchHistory.tsx
@@ -5,7 +5,7 @@ import { Button } from './ui/button';
 import { History } from 'lucide-react';
 
 interface SearchHistoryProps {
-  onSelect: (query: string, resultId?: string) => void; // Modified to accept resultId
+  onSelect: (id: string, query: string) => void;
 }
 
 const SearchHistory: React.FC<SearchHistoryProps> = ({ onSelect }) => {


### PR DESCRIPTION
## Summary
- adjust SearchHistory onSelect interface to take `(id, query)`
- keep AppLayout usage aligned with new signature

## Testing
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68552f343abc832cba0d463a597aea21