### PR TITLE
Unify cache webhook variable

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+node_modules/
+dev-dist/

--- a/docs/cache-sync-implementation.md
+++ b/docs/cache-sync-implementation.md
@@ -91,7 +91,7 @@ graph TD
 
 ### Configuring the Webhook URL
 
-- Set the environment variable `VITE_WEBHOOK_URL` in a `.env` file or directly in your deployment environment to specify the target webhook for cache data synchronization. If not set, it defaults to a predefined URL or a local fallback like `http://localhost:8080/sync-cache`.
+- Set the environment variable `VITE_CACHE_WEBHOOK_URL` in a `.env` file or directly in your deployment environment to specify the target webhook for cache data synchronization. If not set, it defaults to a predefined URL or a local fallback like `http://localhost:8080/sync-cache`.
 
 ## Debugging and Troubleshooting
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from "eslint-plugin-react-refresh";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(
-  { ignores: ["dist"] },
+  { ignores: ["dist", "dev-dist"] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ["**/*.{ts,tsx}"],


### PR DESCRIPTION
## Summary
- document `VITE_CACHE_WEBHOOK_URL` usage
- ignore build output when running ESLint

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68552f2c6a64832ca1610d9eb78ea883