### PR TITLE
Restrict logs to development

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { useToast } from "@/components/ui/use-toast";
 import { useEffect } from "react";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import { logger } from "./utils/logger";
 
 const queryClient = new QueryClient();
 
@@ -18,9 +19,9 @@ const App = () => {
   useEffect(() => {
     if ('serviceWorker' in navigator) {
       const handleMessage = (event: MessageEvent) => {
-        console.log('App.tsx: Received message from Service Worker:', event.data);
+        logger.log('App.tsx: Received message from Service Worker:', event.data);
         if (event.data && event.data.type === 'SYNC_SUCCESS_NOTIFICATION') {
-          console.log('App.tsx: Showing toast for successful sync');
+          logger.log('App.tsx: Showing toast for successful sync');
           toast({
             title: "Sync Successful",
             description: "Synchronizing your search for better results",
@@ -30,11 +31,11 @@ const App = () => {
       };
 
       navigator.serviceWorker.addEventListener('message', handleMessage);
-      console.log('App.tsx: Added message listener for Service Worker messages');
+      logger.log('App.tsx: Added message listener for Service Worker messages');
 
       return () => {
         navigator.serviceWorker.removeEventListener('message', handleMessage);
-        console.log('App.tsx: Removed message listener for Service Worker messages');
+        logger.log('App.tsx: Removed message listener for Service Worker messages');
       };
     }
   }, [toast]);

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 import SearchEngine from './SearchEngine';
 import SearchHistory from './SearchHistory';
 import { Sheet, SheetContent, SheetTitle } from './ui/sheet';
+import { logger } from '../utils/logger';
 import { useAppContext } from '@/contexts/AppContext';
 
 const AppLayout: React.FC = () => {
@@ -9,7 +10,7 @@ const AppLayout: React.FC = () => {
   
   // This function will be passed from SearchEngine
   let handleHistoryClick: (historyId: string, query: string) => void = () => {
-    console.log("handleHistoryClick not yet initialized");
+    logger.log("handleHistoryClick not yet initialized");
   };
 
   // Function to set the handleHistoryClick from SearchEngine

--- a/src/components/SearchEngine.tsx
+++ b/src/components/SearchEngine.tsx
@@ -6,6 +6,7 @@ import { Home, Brain, History, Sparkles } from 'lucide-react';
 import SearchBar from './SearchBar';
 import { searchWithDeepSeek } from '@/services/searchService';
 import type { SearchResult } from '../types/search';
+import { logger } from '../utils/logger';
 
 export interface HistoryItem {
   id: string;
@@ -31,9 +32,9 @@ const SearchEngine: React.FC<SearchEngineProps> = ({ setHandleHistoryClick }) =>
       try {
         const history = await getSearchHistory();
         setHistoryItems(history);
-        console.log("History loaded:", history);
+        logger.log("History loaded:", history);
       } catch (error) {
-        console.error("Failed to load history:", error);
+        logger.error("Failed to load history:", error);
       }
     };
     
@@ -60,7 +61,7 @@ const SearchEngine: React.FC<SearchEngineProps> = ({ setHandleHistoryClick }) =>
         });
       }
     } catch (error) {
-      console.error('Search failed:', error);
+      logger.error('Search failed:', error);
       setCurrentSearchResult({
         id: `error-${Date.now()}`,
         title: `SearchGPT: ${query}`,
@@ -98,7 +99,7 @@ const SearchEngine: React.FC<SearchEngineProps> = ({ setHandleHistoryClick }) =>
         setForceUpdate(prev => prev + 1); // Force re-render
       }
     } catch (error) {
-      console.error('Follow-up search failed:', error);
+      logger.error('Follow-up search failed:', error);
       // Reset isReplying on error
       setCurrentSearchResult({
         ...currentSearchResult,
@@ -110,7 +111,7 @@ const SearchEngine: React.FC<SearchEngineProps> = ({ setHandleHistoryClick }) =>
 
   // Handle history item click
   const handleHistoryClick = useCallback((historyId: string, query: string) => {
-    console.log(`History item clicked: ${historyId}`);
+    logger.log(`History item clicked: ${historyId}`);
     // Use the same search logic as a new query to leverage built-in caching
     handleSearch(query);
   }, [handleSearch]);

--- a/src/components/SearchHistory.tsx
+++ b/src/components/SearchHistory.tsx
@@ -3,6 +3,7 @@ import { useAppContext } from '@/contexts/AppContext';
 import { SearchHistoryItem } from '@/types/search';
 import { Button } from './ui/button';
 import { History } from 'lucide-react';
+import { logger } from '../utils/logger';
 
 interface SearchHistoryProps {
   onSelect: (id: string, query: string) => void;
@@ -34,7 +35,7 @@ const SearchHistory: React.FC<SearchHistoryProps> = ({ onSelect }) => {
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
-              console.log('[DEBUG] History item clicked:', item);
+              logger.log('[DEBUG] History item clicked:', item);
               onSelect(item.id, item.query);
             }}
           >

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -4,6 +4,7 @@ import './SearchResults.css';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
+import { logger } from '../utils/logger';
 import ThreadedSearchResult from './ThreadedSearchResult';
 import { Input } from './ui/input';
 import { Button } from './ui/button';
@@ -18,7 +19,7 @@ const SearchResults: React.FC<SearchResultsProps> = ({ result, isLoading, onFoll
   const [followUpQuery, setFollowUpQuery] = useState<string>('');
   
   useEffect(() => {
-    console.log("SearchResults rendered with result:", result);
+    logger.log("SearchResults rendered with result:", result);
   }, [result]);
 
   // Parse sources to create a map of citation numbers to URLs
@@ -41,11 +42,11 @@ const SearchResults: React.FC<SearchResultsProps> = ({ result, isLoading, onFoll
   const handleFollowUpSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (followUpQuery.trim() && onFollowUp && result) {
-      console.log("Submitting follow-up query for result ID:", result.id, "Query:", followUpQuery);
+      logger.log("Submitting follow-up query for result ID:", result.id, "Query:", followUpQuery);
       await onFollowUp(result.id, followUpQuery);
       setFollowUpQuery('');
     } else {
-      console.log("Follow-up submission blocked. onFollowUp:", !!onFollowUp, "result:", !!result, "query:", followUpQuery);
+      logger.log("Follow-up submission blocked. onFollowUp:", !!onFollowUp, "result:", !!result, "query:", followUpQuery);
     }
   };
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import { logger } from './utils/logger'
 
 // Function to register the Service Worker
 function registerServiceWorker() {
@@ -16,56 +17,56 @@ function registerServiceWorker() {
       function sendSWConfig() {
         const controller = navigator.serviceWorker.controller;
         if (controller) {
-          console.log('Sending configuration to Service Worker:', controller);
+          logger.log('Sending configuration to Service Worker:', controller);
           controller.postMessage({ type: 'SET_CONFIG', webhookUrl: webhookUrl, useMock: false });
           if (import.meta.env.DEV) {
             controller.postMessage({ type: 'SET_DEBUG_MODE', debugMode: true });
-            console.log('Service Worker debug mode set to ON for development');
+            logger.log('Service Worker debug mode set to ON for development');
           }
         } else {
-          console.warn('No Service Worker controller available to send config');
+          logger.warn('No Service Worker controller available to send config');
         }
       }
 
       // Listen for controller change events to send config when a new SW takes control
       navigator.serviceWorker.addEventListener('controllerchange', () => {
-        console.log('Service Worker controllerchange event fired');
+        logger.log('Service Worker controllerchange event fired');
         if (navigator.serviceWorker.controller) {
           sendSWConfig();
         } else {
-          console.warn('Controllerchange fired but no controller available yet');
+          logger.warn('Controllerchange fired but no controller available yet');
         }
       });
 
       // Ensure configuration is sent when Service Worker is ready
       navigator.serviceWorker.ready.then(() => {
-        console.log('Service Worker ready, sending configuration now');
-        console.log('Service Worker controller state at ready:', navigator.serviceWorker.controller ? 'Controller exists' : 'No controller');
-        console.log('Diagnostic: Service Worker controller at ready:', navigator.serviceWorker.controller);
+        logger.log('Service Worker ready, sending configuration now');
+        logger.log('Service Worker controller state at ready:', navigator.serviceWorker.controller ? 'Controller exists' : 'No controller');
+        logger.log('Diagnostic: Service Worker controller at ready:', navigator.serviceWorker.controller);
         if (navigator.serviceWorker.controller) {
           sendSWConfig();
         } else {
-          console.log('No controller available yet, configuration will be sent on controllerchange or activation message');
+          logger.log('No controller available yet, configuration will be sent on controllerchange or activation message');
         }
       });
 
       // Register the Service Worker without manual cache-busting
-      console.log(`Registering Service Worker: ${swUrl}`);
+      logger.log(`Registering Service Worker: ${swUrl}`);
       navigator.serviceWorker.register(swUrl, {
         type: import.meta.env.DEV ? 'classic' : 'classic',
         scope: '/'
       })
         .then(registration => {
-          console.log(`Service Worker registered with scope: ${registration.scope}`);
+          logger.log(`Service Worker registered with scope: ${registration.scope}`);
           // If controller already active, send config immediately
           if (navigator.serviceWorker.controller) {
-            console.log('Active controller detected post-registration');
+            logger.log('Active controller detected post-registration');
             sendSWConfig();
           } else {
-            console.log('Awaiting controllerchange to send config');
+            logger.log('Awaiting controllerchange to send config');
           }
         })
-        .catch(error => console.error('Service Worker registration failed:', error));
+        .catch(error => logger.error('Service Worker registration failed:', error));
     });
   }
 }
@@ -86,43 +87,43 @@ if ('serviceWorker' in navigator) {
   // Use the same webhookUrl as defined earlier for consistency
   const webhookUrl = import.meta.env.VITE_CACHE_WEBHOOK_URL;
   navigator.serviceWorker.addEventListener('message', (event) => {
-    console.log('Main thread: Received message from Service Worker:', event.data);
+    logger.log('Main thread: Received message from Service Worker:', event.data);
     if (event.data && event.data.type === 'REQUEST_CACHE_DATA') {
-      console.log('Main thread: Service Worker requested cache data');
+      logger.log('Main thread: Service Worker requested cache data');
       getAllCacheEntries().then(cacheEntries => {
-        console.log('Main thread: Sending cache data to Service Worker:', cacheEntries.length, 'entries');
+        logger.log('Main thread: Sending cache data to Service Worker:', cacheEntries.length, 'entries');
         if (event.ports && event.ports[0]) {
-          console.log('Main thread: About to send response via message port to Service Worker');
+          logger.log('Main thread: About to send response via message port to Service Worker');
           event.ports[0].postMessage({ cacheEntries });
-          console.log('Main thread: Response sent to Service Worker via message port');
+          logger.log('Main thread: Response sent to Service Worker via message port');
         } else {
-          console.warn('Main thread: No message port available to respond to Service Worker');
-          console.warn('Main thread: event.ports is', event.ports ? 'defined' : 'undefined');
+          logger.warn('Main thread: No message port available to respond to Service Worker');
+          logger.warn('Main thread: event.ports is', event.ports ? 'defined' : 'undefined');
         }
       }).catch(error => {
-        console.error('Main thread: Error fetching cache data for Service Worker:', error);
+        logger.error('Main thread: Error fetching cache data for Service Worker:', error);
         if (event.ports && event.ports[0]) {
-          console.log('Main thread: Sending error response to Service Worker via message port');
+          logger.log('Main thread: Sending error response to Service Worker via message port');
           event.ports[0].postMessage({ error: 'Failed to fetch cache data' });
         } else {
-          console.warn('Main thread: No message port available to send error to Service Worker');
+          logger.warn('Main thread: No message port available to send error to Service Worker');
         }
       });
     } else if (event.data && event.data.type === 'SERVICE_WORKER_ACTIVATED') {
-      console.log('Main thread: Service Worker has activated and claimed clients, sending configuration');
+      logger.log('Main thread: Service Worker has activated and claimed clients, sending configuration');
       const controller = navigator.serviceWorker.controller;
       if (controller) {
-        console.log('Sending configuration to Service Worker:', controller);
+        logger.log('Sending configuration to Service Worker:', controller);
         controller.postMessage({ type: 'SET_CONFIG', webhookUrl, useMock: false });
         if (import.meta.env.DEV) {
           controller.postMessage({ type: 'SET_DEBUG_MODE', debugMode: true });
-          console.log('Service Worker debug mode set to ON for development');
+          logger.log('Service Worker debug mode set to ON for development');
         }
       } else {
-        console.warn('No Service Worker controller available to send config');
+        logger.warn('No Service Worker controller available to send config');
       }
     } else if (event.data && event.data.type === 'SYNC_SUCCESS_NOTIFICATION') {
-      console.log('Main thread: Received sync success notification from Service Worker');
+      logger.log('Main thread: Received sync success notification from Service Worker');
       // This will be handled in App.tsx or a component with access to useToast
     }
   });

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,11 +1,12 @@
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
+import { logger } from "../utils/logger";
 
 const NotFound = () => {
   const location = useLocation();
 
   useEffect(() => {
-    console.error(
+    logger.error(
       "404 Error: User attempted to access non-existent route:",
       location.pathname
     );

--- a/src/services/cacheService.ts
+++ b/src/services/cacheService.ts
@@ -1,4 +1,5 @@
 import type { SearchResult, SearchHistoryItem } from '../types/search';
+import { logger } from '../utils/logger';
 
 interface CacheEntry {
   value: SearchResult;
@@ -13,14 +14,14 @@ const HISTORY_KEY = 'search-history';
 // Store individual results by their ID and maintain thread structure
 export const saveSearchResult = async (result: SearchResult): Promise<void> => {
   try {
-    console.log('CacheService: Saving search result to cache:', result.id);
+    logger.log('CacheService: Saving search result to cache:', result.id);
     const entry: CacheEntry = {
       value: result,
       expires: Date.now() + CACHE_TTL,
       timestamp: Date.now()
     };
     
-    console.log('CacheService: Created cache entry with timestamp:', new Date(entry.timestamp).toISOString());
+    logger.log('CacheService: Created cache entry with timestamp:', new Date(entry.timestamp).toISOString());
     // Save the main result
     localStorage.setItem(`${CONVERSATION_PREFIX}${result.id}`, JSON.stringify(entry));
 
@@ -49,32 +50,32 @@ export const saveSearchResult = async (result: SearchResult): Promise<void> => {
       }
     }
   } catch (error) {
-    console.error('Cache write error:', error);
+    logger.error('Cache write error:', error);
   }
 };
 
 // Get individual result by ID
 export const getSearchResult = async (id: string): Promise<SearchResult | null> => {
   try {
-    console.log('CacheService: Getting search result from cache:', id);
+    logger.log('CacheService: Getting search result from cache:', id);
     const cached = localStorage.getItem(`${CONVERSATION_PREFIX}${id}`);
     if (!cached) {
-      console.log('CacheService: No cached entry found for ID:', id);
+      logger.log('CacheService: No cached entry found for ID:', id);
       return null;
     }
 
     const entry: CacheEntry = JSON.parse(cached);
-    console.log('CacheService: Found cached entry with timestamp:', new Date(entry.timestamp).toISOString());
+    logger.log('CacheService: Found cached entry with timestamp:', new Date(entry.timestamp).toISOString());
     
     if (Date.now() > entry.expires) {
-      console.log('CacheService: Cached entry expired, removing from cache');
+      logger.log('CacheService: Cached entry expired, removing from cache');
       localStorage.removeItem(`${CONVERSATION_PREFIX}${id}`);
       return null;
     }
-    console.log('CacheService: Returning cached result');
+    logger.log('CacheService: Returning cached result');
     return entry.value;
   } catch (error) {
-    console.error('Cache read error:', error);
+    logger.error('Cache read error:', error);
     return null;
   }
 };
@@ -99,10 +100,10 @@ export const getAllSearchResults = async (): Promise<SearchResult[]> => {
         }
       }
     }
-    console.log('CacheService: Retrieved all search results from cache:', results.length, 'entries');
+    logger.log('CacheService: Retrieved all search results from cache:', results.length, 'entries');
     return results;
   } catch (error) {
-    console.error('CacheService: Error retrieving all search results from cache:', error);
+    logger.error('CacheService: Error retrieving all search results from cache:', error);
     return [];
   }
 };
@@ -131,7 +132,7 @@ export const getConversationThread = async (rootId: string): Promise<SearchResul
 
     return await buildThread(rootResult);
   } catch (error) {
-    console.error('Thread build error:', error);
+    logger.error('Thread build error:', error);
     return null;
   }
 };
@@ -160,7 +161,7 @@ export const getAllRootConversations = async (): Promise<SearchResult[]> => {
       return timestampB - timestampA;
     });
   } catch (error) {
-    console.error('Cache read error:', error);
+    logger.error('Cache read error:', error);
     return [];
   }
 };
@@ -174,7 +175,7 @@ export const saveSearchHistoryItem = async (item: SearchHistoryItem): Promise<vo
     ].slice(0, 50); // Keep only last 50 items
     localStorage.setItem(HISTORY_KEY, JSON.stringify(updatedHistory));
   } catch (error) {
-    console.error('History save error:', error);
+    logger.error('History save error:', error);
   }
 };
 
@@ -183,7 +184,7 @@ export const getSearchHistory = async (): Promise<SearchHistoryItem[]> => {
     const history = localStorage.getItem(HISTORY_KEY);
     return history ? JSON.parse(history) : [];
   } catch (error) {
-    console.error('History read error:', error);
+    logger.error('History read error:', error);
     return [];
   }
 };
@@ -192,7 +193,7 @@ export const clearSearchHistory = async (): Promise<void> => {
   try {
     localStorage.removeItem(HISTORY_KEY);
   } catch (error) {
-    console.error('History clear error:', error);
+    logger.error('History clear error:', error);
   }
 };
 
@@ -204,7 +205,7 @@ interface CacheEntryForSync {
 
 export const getAllCacheEntries = async (): Promise<CacheEntryForSync[]> => {
   try {
-    console.log('CacheService: Getting all cache entries for sync');
+    logger.log('CacheService: Getting all cache entries for sync');
     const entries: CacheEntryForSync[] = [];
     for (let i = 0; i < localStorage.length; i++) {
       const key = localStorage.key(i);
@@ -212,18 +213,18 @@ export const getAllCacheEntries = async (): Promise<CacheEntryForSync[]> => {
         try {
           const item = JSON.parse(localStorage.getItem(key) || '{}') as CacheEntryForSync;
           if (item.value && item.timestamp) {
-            console.log('CacheService: Found valid cache entry:', key, 'with timestamp:', new Date(item.timestamp).toISOString());
+            logger.log('CacheService: Found valid cache entry:', key, 'with timestamp:', new Date(item.timestamp).toISOString());
             entries.push(item);
           }
         } catch (e) {
-          console.error('Error parsing cache entry from localStorage:', e);
+          logger.error('Error parsing cache entry from localStorage:', e);
         }
       }
     }
-    console.log('CacheService: Total valid cache entries found:', entries.length);
+    logger.log('CacheService: Total valid cache entries found:', entries.length);
     return entries;
   } catch (error) {
-    console.error('Cache read error:', error);
+    logger.error('Cache read error:', error);
     return [];
   }
 };
@@ -236,6 +237,6 @@ export const clearCache = async (): Promise<void> => {
       }
     });
   } catch (error) {
-    console.error('Cache clear error:', error);
+    logger.error('Cache clear error:', error);
   }
 };

--- a/src/utils/clearCache.js
+++ b/src/utils/clearCache.js
@@ -1,17 +1,18 @@
 // src/utils/clearCache.js
 // This script will clear all local storage items related to search cache
+import { logger } from './logger';
 
-console.log('Clearing search cache from local storage...');
+logger.log('Clearing search cache from local storage...');
 
 try {
   // Remove all items with the 'conv_' prefix
   Object.keys(localStorage).forEach(key => {
     if (key.startsWith('conv_')) {
       localStorage.removeItem(key);
-      console.log(`Removed cache entry: ${key}`);
+      logger.log(`Removed cache entry: ${key}`);
     }
   });
-  console.log('Search cache cleared successfully.');
+  logger.log('Search cache cleared successfully.');
 } catch (error) {
-  console.error('Error clearing search cache:', error);
+  logger.error('Error clearing search cache:', error);
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,13 @@
+const isDevelopment = process.env.NODE_ENV === 'development';
+
+export const logger = {
+  log: (...args: unknown[]) => {
+    if (isDevelopment) console.log(...args);
+  },
+  warn: (...args: unknown[]) => {
+    if (isDevelopment) console.warn(...args);
+  },
+  error: (...args: unknown[]) => {
+    if (isDevelopment) console.error(...args);
+  }
+};

--- a/src/utils/serviceWorkerMessenger.ts
+++ b/src/utils/serviceWorkerMessenger.ts
@@ -1,5 +1,6 @@
 // src/utils/serviceWorkerMessenger.ts
 // Utility to handle communication with the Service Worker, ensuring it's ready before sending messages.
+import { logger } from './logger';
 
 /**
  * Sends a message to the Service Worker, waiting for it to be ready if necessary.
@@ -11,38 +12,38 @@
 export function sendToServiceWorker(message: object, retries = 30, delay = 1000): Promise<void> {
   return new Promise((resolve, reject) => {
     if (!('serviceWorker' in navigator)) {
-      console.error('Service Worker not supported in this environment.');
+      logger.error('Service Worker not supported in this environment.');
       reject(new Error('Service Worker not supported'));
       return;
     }
 
     // Function to attempt sending the message
     const attemptSend = (remainingRetries: number) => {
-      console.log('[SW Messenger] Checking Service Worker controller state:', navigator.serviceWorker.controller ? 'Controller exists' : 'No controller');
+      logger.log('[SW Messenger] Checking Service Worker controller state:', navigator.serviceWorker.controller ? 'Controller exists' : 'No controller');
       
       if (navigator.serviceWorker.controller) {
-        console.log('[SW Messenger] Sending message to Service Worker:', message);
+        logger.log('[SW Messenger] Sending message to Service Worker:', message);
         navigator.serviceWorker.controller.postMessage(message);
         resolve();
       } else if (remainingRetries > 0) {
-        console.log(`[SW Messenger] No active Service Worker controller found, retrying... Retries left: ${remainingRetries}`);
+        logger.log(`[SW Messenger] No active Service Worker controller found, retrying... Retries left: ${remainingRetries}`);
         setTimeout(() => attemptSend(remainingRetries - 1), delay);
       } else {
-        console.error('[SW Messenger] No active Service Worker controller found after retries.');
+        logger.error('[SW Messenger] No active Service Worker controller found after retries.');
         // Attempt to re-register the Service Worker as a last resort
         navigator.serviceWorker.register('/sw.js', {
           scope: '/'
         }).then(registration => {
-          console.log(`[SW Messenger] Re-registered Service Worker with scope: ${registration.scope}`);
+          logger.log(`[SW Messenger] Re-registered Service Worker with scope: ${registration.scope}`);
           if (navigator.serviceWorker.controller) {
-            console.log('[SW Messenger] Controller found after re-registration, sending message');
+            logger.log('[SW Messenger] Controller found after re-registration, sending message');
             navigator.serviceWorker.controller.postMessage(message);
             resolve();
           } else {
             reject(new Error('No active Service Worker controller found even after re-registration'));
           }
         }).catch(error => {
-          console.error('[SW Messenger] Re-registration of Service Worker failed:', error);
+          logger.error('[SW Messenger] Re-registration of Service Worker failed:', error);
           reject(new Error('No active Service Worker controller found after retries and re-registration failed'));
         });
       }
@@ -50,10 +51,10 @@ export function sendToServiceWorker(message: object, retries = 30, delay = 1000)
 
     // First, check if the Service Worker is already ready
     navigator.serviceWorker.ready.then(() => {
-      console.log('[SW Messenger] Service Worker is ready, proceeding to send message.');
+      logger.log('[SW Messenger] Service Worker is ready, proceeding to send message.');
       attemptSend(retries);
     }).catch(error => {
-      console.error('[SW Messenger] Error waiting for Service Worker to be ready:', error);
+      logger.error('[SW Messenger] Error waiting for Service Worker to be ready:', error);
       reject(error);
     });
   });
@@ -65,7 +66,7 @@ export function sendToServiceWorker(message: object, retries = 30, delay = 1000)
  * @returns Promise that resolves when the message is sent.
  */
 export function sendSearchResultsToServiceWorker(results: object[]): Promise<void> {
-  console.log('[SW Messenger] Invoking sendSearchResultsToServiceWorker with results:', results.length, 'entries');
+  logger.log('[SW Messenger] Invoking sendSearchResultsToServiceWorker with results:', results.length, 'entries');
   return sendToServiceWorker({
     type: 'CACHE_NEW_ENTRY',
     results: results


### PR DESCRIPTION
## Summary
- centralize dev logging via `logger`
- avoid leaking sensitive URLs by gating service worker logs
- wrap search, cache, and UI logs with the dev logger

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68555b7366ac832cbb25f4642c165bb9