### PR TITLE
Update service worker build

### DIFF
--- a/build-sw.js
+++ b/build-sw.js
@@ -7,6 +7,9 @@ esbuild.build({
   bundle: true,
   platform: 'browser',
   outfile: 'public/service-worker-dev.js',
+  define: {
+    'import.meta.env.DEV': process.env.NODE_ENV === 'development' ? 'true' : 'false'
+  }
 }).then(() => {
   console.log('Service Worker built successfully to public/service-worker-dev.js');
 }).catch((error) => {

--- a/public/service-worker-dev.js
+++ b/public/service-worker-dev.js
@@ -2506,10 +2506,19 @@
   }
 
   // src/utils/logger.ts
-  import { logger } from 'src/utils/logger.ts';
+  var isDevelopment = false;
+  var logger2 = {
+    log: (...args) => {
+      if (isDevelopment) console.log(...args);
+    },
+    warn: (...args) => {
+      if (isDevelopment) console.warn(...args);
+    },
+    error: (...args) => {
+      if (isDevelopment) console.error(...args);
+    }
+  };
 
-  const logger2 = logger;
-  
   // src/utils/timestampUtils.ts
   function toMillis(input, defaultValue = 0) {
     if (typeof input === "number") return input;


### PR DESCRIPTION
## Summary
- set `import.meta.env.DEV` in `build-sw.js`
- regenerate the development service worker with the updated build script

## Testing
- `npm run build-sw`

------
https://chatgpt.com/codex/tasks/task_e_68556ad043f4832cba85821ffadae545