### PR TITLE
Add ServiceWorkerConfigMessage type

### DIFF
--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -12,6 +12,7 @@ import { NetworkOnly } from 'workbox-strategies';
 import { BackgroundSyncPlugin } from 'workbox-background-sync';
 import { setCacheNameDetails } from 'workbox-core';
 import { logger } from './utils/logger';
+import type { ServiceWorkerConfigMessage } from './types/service-worker-messages';
 
 /* eslint-disable no-console */
 // Placeholder for Workbox manifest injection
@@ -41,7 +42,7 @@ self.addEventListener('message', (event: ExtendableMessageEvent) => {
   logger.log('Service Worker: Raw message event received:', event);
   logger.log('Service Worker: Raw message data:', event.data);
   logger.log('*** SERVICE WORKER: MESSAGE RECEIVED ***', event.data);
-  const data = event.data as { type?: string; webhookUrl?: string; debugMode?: boolean; results?: unknown[] };
+  const data = event.data as ServiceWorkerConfigMessage | { type?: string; debugMode?: boolean; results?: unknown[] };
   if (data) {
     if (data.type === 'SET_CONFIG' && data.webhookUrl) {
       webhookUrl = data.webhookUrl;

--- a/src/types/service-worker-messages.d.ts
+++ b/src/types/service-worker-messages.d.ts
@@ -1,0 +1,4 @@
+export interface ServiceWorkerConfigMessage {
+  type: 'SET_CONFIG';
+  webhookUrl: string;
+}


### PR DESCRIPTION
## Summary
- define `ServiceWorkerConfigMessage` interface for config messages
- use new type instead of inline assertion in service worker

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6856963bf7d4832ca79df12675a6cba8