### PR TITLE
Use precacheAndRoute for SW manifest

### DIFF
--- a/public/service-worker-dev.js
+++ b/public/service-worker-dev.js
@@ -2530,8 +2530,8 @@
   }
 
   // src/service-worker.ts
-  var manifest = self.__WB_MANIFEST;
-  logger2.log("Service Worker: Workbox manifest placeholder initialized", manifest);
+  precacheAndRoute(self.__WB_MANIFEST);
+  logger2.log("Service Worker: Workbox manifest placeholder initialized", self.__WB_MANIFEST);
   setCacheNameDetails({
     prefix: "search-gpt",
     suffix: "v1",

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -11,16 +11,17 @@ import { registerRoute } from 'workbox-routing';
 import { NetworkOnly } from 'workbox-strategies';
 import { BackgroundSyncPlugin } from 'workbox-background-sync';
 import { setCacheNameDetails } from 'workbox-core';
+import { precacheAndRoute } from 'workbox-precaching';
 import { logger } from './utils/logger';
 import type { ServiceWorkerConfigMessage } from './types/service-worker-messages';
 
 /* eslint-disable no-console */
 // Placeholder for Workbox manifest injection
 // This is where Workbox will inject the list of files to precache
-const manifest = self.__WB_MANIFEST;
+precacheAndRoute(self.__WB_MANIFEST);
 
 // Log the manifest to ensure it's recognized during build
-logger.log('Service Worker: Workbox manifest placeholder initialized', manifest);
+logger.log('Service Worker: Workbox manifest placeholder initialized', self.__WB_MANIFEST);
 
 // Set cache names (optional, but good practice)
 setCacheNameDetails({


### PR DESCRIPTION
## Summary
- import `precacheAndRoute` in the service worker
- precache manifest files in both dev and prod workers

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6856a1d97688832c80d21f300b38cda1