### PR TITLE
Update cache similarity env vars in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ This project uses environment variables to manage sensitive information and conf
 - `VITE_SUPABASE_EDGE_FUNCTION_URL`: The URL for Supabase edge functions used in search operations.
 - `VITE_CACHE_SYNC_INTERVAL`: The interval (in milliseconds) for cache synchronization.
 - `VITE_CACHE_WEBHOOK_URL`: The webhook URL for cache data synchronization.
+- `VITE_CACHE_SIMILARITY_QUERY_URL`: The endpoint for cache similarity webhook calls.
+- `VITE_CACHE_SIMILARITY_API_KEY`: The API key for the cache similarity service.
 - `VITE_SW_MINIFY`: A boolean flag to determine if the Service Worker should be minified.
 
 These variables have been integrated into the codebase to replace hardcoded values, ensuring better security and configurability. The changes have been applied to:

--- a/docs/quick-cached-results-implementation.md
+++ b/docs/quick-cached-results-implementation.md
@@ -42,7 +42,7 @@ graph TD
 ```typescript
 // Example API call
 async function cacheSimilarityQuery(query: string) {
-  const response = await fetch(CACHE_SIMILARITY_URL, {
+  const response = await fetch(process.env.VITE_CACHE_SIMILARITY_QUERY_URL, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/docs/quick-cached-results-implementation.md
+++ b/docs/quick-cached-results-implementation.md
@@ -42,11 +42,11 @@ graph TD
 ```typescript
 // Example API call
 async function cacheSimilarityQuery(query: string) {
-  const response = await fetch(CACHE_SIMILARITY_QUERY, {
+  const response = await fetch(CACHE_SIMILARITY_URL, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'x-make-apikey': process.env.VITE_MAKE_API_KEY
+      'x-make-apikey': process.env.VITE_CACHE_SIMILARITY_API_KEY
     },
     body: JSON.stringify({
       query,
@@ -61,8 +61,8 @@ async function cacheSimilarityQuery(query: string) {
 ### Environment Variables
 Add to `.env.local`:
 ```env
-VITE_CACHE_SIMILARITY_QUERY=your_make_webhook_url
-VITE_MAKE_API_KEY=your_make_api_key
+VITE_CACHE_SIMILARITY_QUERY_URL=your_webhook_url
+VITE_CACHE_SIMILARITY_API_KEY=your_api_key
 ```
 
 ## Supabase Tables


### PR DESCRIPTION
## Summary
- update client code snippet with new env variable names
- document `VITE_CACHE_SIMILARITY_QUERY_URL` and `VITE_CACHE_SIMILARITY_API_KEY`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686e567e1d10832c98bec64108d9fda6