### PR TITLE
Enable offline cache sync with Workbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,8 +84,12 @@
         "vaul": "^0.9.3",
         "vite": "^5.4.1",
         "vite-plugin-pwa": "^1.0.0",
+        "workbox-background-sync": "^7.3.0",
         "workbox-build": "^7.3.0",
         "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": "20.x"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1",
+    "workbox-background-sync": "^7.3.0",
     "workbox-build": "^7.3.0"
   }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,6 +11,11 @@ if ('serviceWorker' in navigator) {
     const swPath = import.meta.env.PROD ? '/sw.js' : '/dev-sw.js?dev-sw';
     navigator.serviceWorker.register(swPath, { type: 'module' }).then(registration => {
       logger.log('Service Worker registered with scope:', registration.scope);
+      if (registration.sync) {
+        registration.sync.register('sync-cache').catch(err => {
+          logger.error('Background sync registration failed:', err);
+        });
+      }
     }).catch(error => {
       logger.error('Service Worker registration failed:', error);
     });

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -1,8 +1,13 @@
 import { precacheAndRoute } from 'workbox-precaching';
+import { registerRoute } from 'workbox-routing';
+import { NetworkOnly } from 'workbox-strategies';
+import { BackgroundSyncPlugin } from 'workbox-background-sync';
 import { logger } from './utils/logger';
 import type { SearchResult } from './types/search';
 
 declare const self: ServiceWorkerGlobalScope;
+
+const cacheSyncQueue = new BackgroundSyncPlugin('sync-cache');
 
 interface SyncPayload {
   webhookUrl: string;
@@ -45,6 +50,16 @@ const handleSync = async (data: SyncPayload) => {
   }
 };
 
+const webhookUrl = import.meta.env.VITE_CACHE_WEBHOOK_URL;
+
+if (webhookUrl) {
+  registerRoute(
+    ({ url, request }) => request.method === 'POST' && url.href === webhookUrl,
+    new NetworkOnly({ plugins: [cacheSyncQueue] }),
+    'POST'
+  );
+}
+
 self.addEventListener('message', (event: ExtendableMessageEvent) => {
   const data = event.data as { type: string; payload?: SyncPayload };
   if (!data) return;
@@ -70,4 +85,11 @@ self.addEventListener('activate', (event: ExtendableEvent) => {
 self.addEventListener('install', () => {
   logger.log('SW: Installed. Forcing activation.');
   self.skipWaiting();
+});
+
+self.addEventListener('sync', event => {
+  if (event.tag === 'workbox-background-sync:sync-cache') {
+    logger.log('SW: Background sync event received');
+    // Workbox handles replaying queued requests automatically
+  }
 });


### PR DESCRIPTION
## Summary
- add `workbox-background-sync` package
- queue POST requests to the cache webhook in the service worker
- register `sync-cache` after service worker registration

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686e56845550832cae1a9fa411a97532