### PR TITLE
Add SW minify env toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ This project uses environment variables to manage sensitive information and conf
 - `VITE_SUPABASE_EDGE_FUNCTION_URL`: The URL for Supabase edge functions used in search operations.
 - `VITE_CACHE_SYNC_INTERVAL`: The interval (in milliseconds) for cache synchronization.
 - `VITE_CACHE_WEBHOOK_URL`: The webhook URL for cache data synchronization.
-- `VITE_SW_MINIFY`: A boolean flag to determine if the Service Worker should be minified.
+- `VITE_SW_MINIFY`: Set to `false` to disable Service Worker minification. The Service Worker is minified by default in production. Use `npm run build:sw-unminified` to build without minification.
 
 These variables have been integrated into the codebase to replace hardcoded values, ensuring better security and configurability. The changes have been applied to:
 - `src/lib/supabase.ts` for Supabase URL and key.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,7 +16,7 @@ export default defineConfig(({ mode }) => ({
       srcDir: 'src',
       filename: 'service-worker.ts',
       registerType: 'autoUpdate',
-      minify: mode === 'production' || process.env.VITE_SW_MINIFY !== 'false',
+      minify: mode === 'production' && process.env.VITE_SW_MINIFY !== 'false',
       workbox: {
         globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
       },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig(({ mode }) => ({
       srcDir: 'src',
       filename: 'service-worker.ts',
       registerType: 'autoUpdate',
+      minify: mode === 'production' || process.env.VITE_SW_MINIFY !== 'false',
       workbox: {
         globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
       },


### PR DESCRIPTION
## Summary
- allow configuring service worker minification via VITE_SW_MINIFY
- document how to disable minification and use `build:sw-unminified`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686e56a696d0832cb522f2e5f5216e9b