### PR TITLE
Simplify service worker registration

### DIFF
--- a/dev-dist/registerSW.js
+++ b/dev-dist/registerSW.js
@@ -1,1 +1,1 @@
-if('serviceWorker' in navigator) navigator.serviceWorker.register('/dev-sw.js?dev-sw', { scope: '/', type: 'module' })
+if('serviceWorker' in navigator) navigator.serviceWorker.register('/sw.js', { scope: '/', type: 'module' })

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,9 +7,7 @@ import './utils/serviceWorkerClient'
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    // Adjust the path based on Vite build output for service worker
-    const swPath = import.meta.env.PROD ? '/sw.js' : '/dev-sw.js?dev-sw';
-    navigator.serviceWorker.register(swPath, { type: 'module' }).then(registration => {
+    navigator.serviceWorker.register('/sw.js', { type: 'module' }).then(registration => {
       logger.log('Service Worker registered with scope:', registration.scope);
       if (registration.sync) {
         registration.sync.register('sync-cache').catch(err => {


### PR DESCRIPTION
## Summary
- register `/sw.js` in production and development
- update generated registerSW script

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e56b75e68832c877ceea8dfea8a93